### PR TITLE
Add theme switch button in app bar

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -205,6 +205,20 @@ class _MainPageState extends State<MainPage>
                       _paraModel.setCurrentPara(_paraModel.currentPara - 1);
                     },
                   ),
+                  IconButton(
+                    onPressed: () {
+                      Settings.instance.themeMode =
+                          Settings.instance.themeMode == ThemeMode.light
+                              ? ThemeMode.dark
+                              : ThemeMode.light;
+                    },
+                    icon: Icon(Settings.instance.themeMode == ThemeMode.light
+                        ? Icons.mode_night
+                        : Icons.sunny),
+                    tooltip: Settings.instance.themeMode == ThemeMode.light
+                        ? "Switch to night mode"
+                        : "Switch to light mode",
+                  ),
                   buildThreeDotMenu()
                 ],
               ),


### PR DESCRIPTION
This allows single tap theme switching without having to go to Settings. Theme switching is quite a common functionality when reading especially if the user switches themes based on surrounding lighting conditions. A similar button can be found in other ebook readers such as FBReader.

If the button doesn't make sense in the app bar, we can move it to the menu instead.