### PR TITLE
Remember scroll position in para & surah list

### DIFF
--- a/lib/widgets/para_list_view.dart
+++ b/lib/widgets/para_list_view.dart
@@ -82,9 +82,10 @@ class ParaListView extends StatelessWidget {
     }
 
     final paraListScrollController = ScrollController(
-        initialScrollOffset: paraScrollTo.toDouble(), keepScrollOffset: false);
+        initialScrollOffset: paraScrollTo.toDouble(), keepScrollOffset: true);
 
     return ListView.builder(
+      key: const PageStorageKey("para_list_view"),
       controller: paraListScrollController,
       scrollDirection: Axis.vertical,
       itemCount: 30,

--- a/lib/widgets/surah_list_view.dart
+++ b/lib/widgets/surah_list_view.dart
@@ -3,6 +3,9 @@ import 'package:quran_memorization_helper/quran_data/surahs.dart';
 import 'package:quran_memorization_helper/quran_data/pages.dart';
 import 'package:quran_memorization_helper/utils/utils.dart';
 
+var lastSurah = 0;
+var lastScrollPosition = 0.0;
+
 class SurahListView extends StatelessWidget {
   final int currentParaIdx;
   final int currentPageInPara;
@@ -15,15 +18,19 @@ class SurahListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int surah = firstSurahInPara(currentParaIdx);
-    double surahScrollTo = 48 * surah.toDouble();
-    final surahListScrollController = ScrollController(
-        initialScrollOffset: surahScrollTo, keepScrollOffset: true);
     int currentPage = currentPageInPara + para16LinePageOffsets[currentParaIdx];
     int currentSurah = surahForPage(currentPage);
+    double surahScrollTo = lastScrollPosition > 0.0 && lastSurah == currentSurah
+        ? lastScrollPosition
+        : 48 * currentSurah.toDouble();
+    final surahListScrollController = ScrollController(
+        initialScrollOffset: surahScrollTo, keepScrollOffset: false);
+    surahListScrollController.addListener(() {
+      lastScrollPosition = surahListScrollController.offset;
+    });
+    lastSurah = currentSurah;
 
     return ListView.builder(
-      key: const PageStorageKey("surah_list_view"),
       controller: surahListScrollController,
       scrollDirection: Axis.vertical,
       itemCount: 114,

--- a/lib/widgets/surah_list_view.dart
+++ b/lib/widgets/surah_list_view.dart
@@ -18,11 +18,12 @@ class SurahListView extends StatelessWidget {
     int surah = firstSurahInPara(currentParaIdx);
     double surahScrollTo = 48 * surah.toDouble();
     final surahListScrollController = ScrollController(
-        initialScrollOffset: surahScrollTo, keepScrollOffset: false);
+        initialScrollOffset: surahScrollTo, keepScrollOffset: true);
     int currentPage = currentPageInPara + para16LinePageOffsets[currentParaIdx];
     int currentSurah = surahForPage(currentPage);
 
     return ListView.builder(
+      key: const PageStorageKey("surah_list_view"),
       controller: surahListScrollController,
       scrollDirection: Axis.vertical,
       itemCount: 114,

--- a/lib/widgets/surah_list_view.dart
+++ b/lib/widgets/surah_list_view.dart
@@ -3,8 +3,8 @@ import 'package:quran_memorization_helper/quran_data/surahs.dart';
 import 'package:quran_memorization_helper/quran_data/pages.dart';
 import 'package:quran_memorization_helper/utils/utils.dart';
 
-var lastSurah = 0;
-var lastScrollPosition = 0.0;
+int lastSurah = 0;
+double? lastScrollPosition;
 
 class SurahListView extends StatelessWidget {
   final int currentParaIdx;
@@ -20,9 +20,10 @@ class SurahListView extends StatelessWidget {
   Widget build(BuildContext context) {
     int currentPage = currentPageInPara + para16LinePageOffsets[currentParaIdx];
     int currentSurah = surahForPage(currentPage);
-    double surahScrollTo = lastScrollPosition > 0.0 && lastSurah == currentSurah
-        ? lastScrollPosition
-        : 48 * currentSurah.toDouble();
+    double surahScrollTo =
+        lastScrollPosition != null && lastSurah == currentSurah
+            ? lastScrollPosition!
+            : 48 * currentSurah.toDouble();
     final surahListScrollController = ScrollController(
         initialScrollOffset: surahScrollTo, keepScrollOffset: false);
     surahListScrollController.addListener(() {


### PR DESCRIPTION
The current behavior of always jumping to the selected surah/para can be quite visually jarring. Since the lists have relatively few items, manually scrolling to see the selected Para/Surah won't be too annoying.

Furthermore, once the Surah & Para indicators are added inside each page, it'll automatically fix that.

Preserving visual state of elements is good UX as it gives a feeling of continuity instead of resetting everything each time you open something.