### PR TITLE
Add page navigation using right/left arrow keys

### DIFF
--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -10,7 +10,7 @@ import 'package:quran_memorization_helper/widgets/surah_list_view.dart';
 import 'package:quran_memorization_helper/widgets/para_list_view.dart';
 import 'package:quran_memorization_helper/utils/utils.dart';
 import 'package:flutter/services.dart'
-    show KeyDownEvent, LogicalKeyboardKey, rootBundle;
+    show HardwareKeyboard, KeyDownEvent, LogicalKeyboardKey, rootBundle;
 
 class MainPage extends StatefulWidget {
   const MainPage({super.key});
@@ -186,11 +186,14 @@ class _MainPageState extends State<MainPage>
               focusNode: _focusNode,
               autofocus: true,
               onKeyEvent: (event) {
+                bool isCtrlPressed =
+                    HardwareKeyboard.instance.isControlPressed ||
+                        HardwareKeyboard.instance.isMetaPressed;
                 if (event is KeyDownEvent &&
                     event.logicalKey == LogicalKeyboardKey.arrowLeft) {
                   int totalPages = pageCountForPara(_paraModel.currentPara - 1);
                   int nextPage = (_pageController.page?.floor() ?? -1) + 1;
-                  if (nextPage >= totalPages) {
+                  if (nextPage >= totalPages || isCtrlPressed) {
                     _paraModel.setCurrentPara(_paraModel.currentPara + 1);
                   } else {
                     _pageController.nextPage(
@@ -200,9 +203,9 @@ class _MainPageState extends State<MainPage>
                 } else if (event is KeyDownEvent &&
                     event.logicalKey == LogicalKeyboardKey.arrowRight) {
                   int previousPage = (_pageController.page?.floor() ?? 1) - 1;
-                  if (previousPage <= 0) {
+                  if (previousPage <= 0 || isCtrlPressed) {
                     _paraModel.setCurrentPara(_paraModel.currentPara - 1,
-                        showLastPage: true);
+                        showLastPage: !isCtrlPressed);
                   } else {
                     _pageController.previousPage(
                         duration: const Duration(milliseconds: 200),

--- a/lib/pages/main_page.dart
+++ b/lib/pages/main_page.dart
@@ -191,7 +191,16 @@ class _MainPageState extends State<MainPage>
                     HardwareKeyboard.instance.isMetaPressed;
                 bool jumpSurah = HardwareKeyboard.instance.isShiftPressed;
                 if (event is KeyDownEvent &&
-                    event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+                    event.logicalKey == LogicalKeyboardKey.home) {
+                  _pageController.jumpToPage(0);
+                }
+                if (event is KeyDownEvent &&
+                    event.logicalKey == LogicalKeyboardKey.end) {
+                  int totalPages = pageCountForPara(_paraModel.currentPara - 1);
+                  _pageController.jumpToPage(totalPages - 1);
+                } else if (event is KeyDownEvent &&
+                    (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
+                        event.logicalKey == LogicalKeyboardKey.pageDown)) {
                   int? currentPageInPara = _pageController.page?.floor();
                   if (jumpSurah) {
                     int currentPage = (currentPageInPara ?? 0) +
@@ -214,7 +223,8 @@ class _MainPageState extends State<MainPage>
                     }
                   }
                 } else if (event is KeyDownEvent &&
-                    event.logicalKey == LogicalKeyboardKey.arrowRight) {
+                    (event.logicalKey == LogicalKeyboardKey.arrowRight ||
+                        event.logicalKey == LogicalKeyboardKey.pageUp)) {
                   int? currentPageInPara = _pageController.page?.floor();
                   if (jumpSurah) {
                     int currentPage = (currentPageInPara ?? 0) +


### PR DESCRIPTION
This adds 8 shortcuts:

1. `ArrowLeft`/`PageDown` to move to next page
2. `ArrowRight`/`PageUp` to move to previous page
4. `Ctrl + ArrowLeft` to move to next para
5. `Ctrl + ArrowRight` to move to previous para
6. `Shift + ArrowLeft` to move to next surah
7. `Shift + ArrowRight` to move to previous surah
8. `Home` to go to start of para
9. `End` to go to end of para

